### PR TITLE
Update like_util.py. Identify Media Type as it was getting as None

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -905,7 +905,7 @@ def get_links(browser, page, logger, media, element):
                         post_category = element.find_element_by_xpath(
                             "//a[@href='/p/"
                             + post_href.split("/")[-2]
-                            + "/']/child::div[@class='u7YqG']/child::span"
+                            + "/']/child::div[@class='u7YqG']/child::div/*[name()='svg']"
                         ).get_attribute("aria-label")
 
                         if post_category in media:


### PR DESCRIPTION
svg tag contains the attribute "aria-label". Updating the changes to read the post_category value

<!-- Did you know that we have a Discord channel ? Join us: https://discord.gg/FDETsht -->
<!-- Is this a Feature Request ? Please, check out our Wiki first https://github.com/timgrossmann/InstaPy/wiki -->
# Pull Request Template

## Description
"svg" tag contains the attribute "aria-label". Updating the changes to read the post_category value


Do not include any personal data.

Fixes # (issue)
post_category will now not have a null value and media type will be recognized.

## How Has This Been Tested?

Execute code function like_by_tags and media argument as photo or video to check if only specific media is liked

- [ ] Test
- [ ] 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project, `black -t py34`
- [ ] My changes generate no new warnings
